### PR TITLE
Show the player map for modded games with tModLoader

### DIFF
--- a/Data/World.cs
+++ b/Data/World.cs
@@ -1690,7 +1690,7 @@ namespace TerraMap.Data
 	  string modUser = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "My Games\\Terraria\\ModLoader\\Players");
       var modDirectory = new DirectoryInfo(modUser);
 
-      foreach (var playerDirectory in modDirectory.GetDirectories())
+      foreach (var playerDirectory in modDirectory.GetDirectories().Where(d => !d.Name.Equals("Backups")))
       {
         var playerName = String.Concat(playerDirectory.Name, " (MOD)");
 

--- a/Data/World.cs
+++ b/Data/World.cs
@@ -1688,18 +1688,18 @@ namespace TerraMap.Data
       }
 	  
 	  string modUser = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "My Games\\Terraria\\ModLoader\\Players");
-      var modDirectory = new DirectoryInfo(modUser);
+        if(Directory.Exists(modUser)){
+            var modDirectory = new DirectoryInfo(modUser);
+            foreach (var moddedPlayerDirectory in modDirectory.GetDirectories().Where(d => !d.Name.Equals("Backups")))
+            {
+                var playerName = String.Concat(moddedPlayerDirectory.Name, " (MOD)");
 
-      foreach (var playerDirectory in modDirectory.GetDirectories().Where(d => !d.Name.Equals("Backups")))
-      {
-        var playerName = String.Concat(playerDirectory.Name, " (MOD)");
+                var playerMapFilename = Path.Combine(moddedPlayerDirectory.FullName, filename);
 
-        var playerMapFilename = Path.Combine(playerDirectory.FullName, filename);
-
-        if (File.Exists(playerMapFilename))
-          playerMapFiles.Add(new MapFileViewModel() { Name = playerName, FileInfo = new FileInfo(playerMapFilename) });
-      }
-
+                if (File.Exists(playerMapFilename))
+                    playerMapFiles.Add(new MapFileViewModel() { Name = playerName, FileInfo = new FileInfo(playerMapFilename) });
+            }
+        }
       string userdataPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
 
       userdataPath = Path.Combine(userdataPath, "Steam");

--- a/Data/World.cs
+++ b/Data/World.cs
@@ -1686,6 +1686,19 @@ namespace TerraMap.Data
         if (File.Exists(playerMapFilename))
           playerMapFiles.Add(new MapFileViewModel() { Name = playerName, FileInfo = new FileInfo(playerMapFilename) });
       }
+	  
+	  string modUser = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "My Games\\Terraria\\ModLoader\\Players");
+      var modDirectory = new DirectoryInfo(modUser);
+
+      foreach (var playerDirectory in modDirectory.GetDirectories())
+      {
+        var playerName = String.Concat(playerDirectory.Name, " (MOD)");
+
+        var playerMapFilename = Path.Combine(playerDirectory.FullName, filename);
+
+        if (File.Exists(playerMapFilename))
+          playerMapFiles.Add(new MapFileViewModel() { Name = playerName, FileInfo = new FileInfo(playerMapFilename) });
+      }
 
       string userdataPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
 

--- a/TerraMap/MainWindow.xaml.cs
+++ b/TerraMap/MainWindow.xaml.cs
@@ -98,6 +98,14 @@ namespace TerraMap
           this.viewModel.WorldFiles.Add(new WorldFileViewModel() { FileInfo = new FileInfo(filename), Name = name });
         }
 
+        var modPath = this.GetModdedWorldsPath();
+
+        foreach (var filename in Directory.GetFiles(modPath, "*.wld"))
+        {
+            string name = World.GetWorldName(filename);
+            this.viewModel.WorldFiles.Add(new WorldFileViewModel() { FileInfo = new FileInfo(filename), Name = String.Concat(name, " (MOD)") });
+        }
+
         var cloudPaths = GetCloudPaths();
 
         foreach (var cloudPath in cloudPaths)
@@ -210,8 +218,18 @@ namespace TerraMap
       path = Path.Combine(path, "Worlds");
       return path;
     }
+    private string GetModdedWorldsPath()
+    {
+        string path = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 
-    private async Task Open()
+        path = Path.Combine(path, "My Games");
+        path = Path.Combine(path, "Terraria");
+        path = Path.Combine(path, "ModLoader");
+        path = Path.Combine(path, "Worlds");
+        return path;
+    }
+
+        private async Task Open()
     {
       string path = this.GetWorldsPath();
 

--- a/TerraMap/MainWindow.xaml.cs
+++ b/TerraMap/MainWindow.xaml.cs
@@ -99,13 +99,14 @@ namespace TerraMap
         }
 
         var modPath = this.GetModdedWorldsPath();
-
-        foreach (var filename in Directory.GetFiles(modPath, "*.wld"))
+        if (Directory.Exists(modPath))
         {
-            string name = World.GetWorldName(filename);
-            this.viewModel.WorldFiles.Add(new WorldFileViewModel() { FileInfo = new FileInfo(filename), Name = String.Concat(name, " (MOD)") });
+            foreach (var filename in Directory.GetFiles(modPath, "*.wld"))
+            {
+                string name = World.GetWorldName(filename);
+                this.viewModel.WorldFiles.Add(new WorldFileViewModel() { FileInfo = new FileInfo(filename), Name = String.Concat(name, " (MOD)") });
+            }
         }
-
         var cloudPaths = GetCloudPaths();
 
         foreach (var cloudPath in cloudPaths)


### PR DESCRIPTION
When opening a modded world with tModLoader the player map would not be loaded. Only a small fix was needed to make it also read the default modded folder.