### PR TITLE
Find proper steam install directory

### DIFF
--- a/Data/World.cs
+++ b/Data/World.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Win32;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -1812,10 +1813,16 @@ namespace TerraMap.Data
                     playerMapFiles.Add(new MapFileViewModel() { Name = playerName, FileInfo = new FileInfo(playerMapFilename) });
             }
         }
-      string userdataPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
 
-      userdataPath = Path.Combine(userdataPath, "Steam");
-      userdataPath = Path.Combine(userdataPath, "userdata");
+        string userdataPath;
+        using (var HKLM = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
+        {
+            using (var steamKey = HKLM.OpenSubKey("SOFTWARE\\Valve\\Steam"))
+            {
+                userdataPath = (string)steamKey.GetValue("InstallPath", Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Steam"));
+            }
+        }
+        userdataPath = Path.Combine(userdataPath, "userdata");
 
       if (Directory.Exists(userdataPath))
       {

--- a/TerraMap/MainWindow.xaml.cs
+++ b/TerraMap/MainWindow.xaml.cs
@@ -135,11 +135,16 @@ namespace TerraMap
     {
       List<string> cloudPaths = new List<string>();
 
-      string userdataPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+      string userdataPath;
+      using (var HKLM = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
+      {
+        using (var steamKey = HKLM.OpenSubKey("SOFTWARE\\Valve\\Steam")) {
+          userdataPath = (string)steamKey.GetValue("InstallPath", Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Steam"));
+        }
+      }
 
       try
       {
-        userdataPath = Path.Combine(userdataPath, "Steam");
         userdataPath = Path.Combine(userdataPath, "userdata");
 
         if (Directory.Exists(userdataPath))


### PR DESCRIPTION
The current hardcoded steam directory for finding cloud files leads to missing characters & worlds if Steam is installed somewhere else.

However, Steam maintains a record in the windows registry of it's install location, which can be used instead (with fallback to the default if the registry entry is, for some reason, missing)